### PR TITLE
Adapt to k8s: use non-privileged 8080 port, run as 'guest' user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM caddy:2.8.4-alpine
 
 COPY caddy /etc/caddy/
 COPY build /site
+RUN chown -R guest /etc/caddy /site /config/caddy /data/caddy
+RUN chown root:root /usr/bin/caddy
+
 # TODO: exclude from production build
 RUN rm -f /site/mockServiceWorker.js
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Run UI via docker
 ```bash
 export API_URL=http://bridge.server.com # url to bridge rest api
 export BASE_HREF=/thrift-rest-bridge-ui # (optional) base url for reverse proxy
-docker run --rm -p 80:80 -e API_URL ghcr.io/artemy-osipov/thrift-rest-bridge-ui:0.5.0
+docker run --rm -p 80:8080 -e API_URL ghcr.io/artemy-osipov/thrift-rest-bridge-ui:0.5.0
 ```
 
 App will be accessible on `http://localhost:80`

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,4 +1,4 @@
-:80
+:8080
 
 root * /site
 file_server


### PR DESCRIPTION
Patch to adapt this app for use in k8s